### PR TITLE
Add custom output prefix option to SDFG export pass

### DIFF
--- a/include/sdfg/Analysis/ExportSDFG/Passes.h
+++ b/include/sdfg/Analysis/ExportSDFG/Passes.h
@@ -2,11 +2,18 @@
 #define SDFG_Analysis_ExportSDFG_Passes_H
 
 #include "mlir/Pass/Pass.h"
+#include <string>
 
 namespace mlir::sdfg::analysis {
 
+// Global variable for output prefix
+extern std::string g_outputPrefix;
+
 // Factory to create the ExportSDFG pass.
 std::unique_ptr<mlir::Pass> createExportSDFGPass();
+
+// Set the output prefix for the ExportSDFG pass.
+void setExportSDFGOutputPrefix(const std::string& prefix);
 
 //===----------------------------------------------------------------------===//
 // Registration

--- a/lib/sdfg/Analysis/ExportSDFG/ExportSDFG.cpp
+++ b/lib/sdfg/Analysis/ExportSDFG/ExportSDFG.cpp
@@ -17,6 +17,10 @@
 namespace {
 
 struct ExportSDFGPass : public mlir::sdfg::analysis::ExportSDFGPassBase<ExportSDFGPass> {
+  std::string outputPrefix_;
+
+  ExportSDFGPass() : outputPrefix_("") {}
+  ExportSDFGPass(const std::string& outputPrefix) : outputPrefix_(outputPrefix) {}
   
   void visit_alloca(sdfg::builder::StructuredSDFGBuilder& builder,
                     mlir::sdfg::AllocaOp allocaOp) {
@@ -189,15 +193,20 @@ struct ExportSDFGPass : public mlir::sdfg::analysis::ExportSDFGPassBase<ExportSD
       // Finish SDFG
       auto sdfg = builder.move();
 
+      // Apply output prefix if provided
+      std::string finalOutputPrefix = mlir::sdfg::analysis::g_outputPrefix.empty() 
+        ? moduleName + "." + sdfgName 
+        : mlir::sdfg::analysis::g_outputPrefix;
+
       sdfg::visualizer::DotVisualizer visualizer(*sdfg);
       visualizer.visualize();
-      std::filesystem::path dotPath = moduleName + "." + sdfgName + ".dot";
+      std::filesystem::path dotPath = finalOutputPrefix + ".dot";
       visualizer.writeToFile(*sdfg, &dotPath);
 
       // Serialize SDFG to JSON
       sdfg::serializer::JSONSerializer serializer;
       auto j = serializer.serialize(*sdfg);
-      std::filesystem::path sdfgPath = moduleName + "." + sdfgName + ".json";
+      std::filesystem::path sdfgPath = finalOutputPrefix + ".json";
 
       std::ofstream ofs(sdfgPath);
       if (!ofs.is_open()) {
@@ -212,6 +221,13 @@ struct ExportSDFGPass : public mlir::sdfg::analysis::ExportSDFGPassBase<ExportSD
 
 } // end anonymous namespace
 
+// Define the global variable
+std::string mlir::sdfg::analysis::g_outputPrefix;
+
 std::unique_ptr<mlir::Pass> mlir::sdfg::analysis::createExportSDFGPass() {
   return std::make_unique<ExportSDFGPass>();
+}
+
+void mlir::sdfg::analysis::setExportSDFGOutputPrefix(const std::string& prefix) {
+  mlir::sdfg::analysis::g_outputPrefix = prefix;
 } 

--- a/sdfg-export/sdfg-export.cpp
+++ b/sdfg-export/sdfg-export.cpp
@@ -14,6 +14,9 @@
 
 #include <sdfg/codegen/dispatchers/node_dispatcher_registry.h>
 #include <sdfg/serializer/json_serializer.h>
+#include <cstdlib>
+#include <vector>
+#include <string>
 
 int main(int argc, char **argv) {
 
@@ -28,6 +31,36 @@ int main(int argc, char **argv) {
   sdfg::codegen::register_default_dispatchers();
   sdfg::serializer::register_default_serializers();
 
+  // Parse command line arguments manually to extract -o option
+  std::string outputPrefix;
+  std::vector<std::string> mlirArgs;
+  
+  for (int i = 1; i < argc; i++) {
+    std::string arg = argv[i];
+    if (arg == "-o" && i + 1 < argc) {
+      outputPrefix = argv[i + 1];
+      i++; // Skip the next argument as well
+    } else if (arg.substr(0, 2) == "-o" && arg.length() > 2) {
+      // Handle -o=value format
+      outputPrefix = arg.substr(2);
+    } else {
+      mlirArgs.push_back(arg);
+    }
+  }
+
+  // Set the output prefix if provided
+  if (!outputPrefix.empty()) {
+    mlir::sdfg::analysis::setExportSDFGOutputPrefix(outputPrefix);
+  }
+
+  // Convert back to argc/argv format for MLIR
+  std::vector<char*> mlirArgv;
+  mlirArgv.push_back(argv[0]); // program name
+  for (const auto& arg : mlirArgs) {
+    mlirArgv.push_back(const_cast<char*>(arg.c_str()));
+  }
+  int mlirArgc = mlirArgv.size();
+
   return mlir::asMainReturnCode(
-      mlir::MlirOptMain(argc, argv, "SDFG exporter\n", registry));
+      mlir::MlirOptMain(mlirArgc, mlirArgv.data(), "SDFG exporter\n", registry));
 } 


### PR DESCRIPTION
This PR adds a simple '-o' option to the SDFG export tool, allowing users to specify custom output file prefixes instead of using the default '{moduleName}.{sdfgName}' naming scheme.

## Usage
```bash
# To create: /path/to/custom_name.dot, /path/to/custom_name.json  
sdfg-export --export-sdfg input.mlir -o /path/to/custom_name
```